### PR TITLE
PR作成時に自動でコミットした人たちをアサイン

### DIFF
--- a/.github/scripts/auto-assign.js
+++ b/.github/scripts/auto-assign.js
@@ -1,0 +1,90 @@
+/**
+ * Auto-assign PR to commit authors
+ *
+ * This script automatically assigns a pull request to all users who have
+ * authored commits in the PR, excluding bot users.
+ *
+ * @param {Object} github - GitHub API client from actions/github-script
+ * @param {Object} context - Workflow context from actions/github-script
+ */
+module.exports = async ({ github, context }) => {
+  try {
+    // Fetch PR commits and current assignees in parallel
+    const [{ data: prCommits }, { data: { assignees } }] = await Promise.all([
+      github.rest.pulls.listCommits({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        pull_number: context.issue.number
+      }),
+      github.rest.pulls.get({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        pull_number: context.issue.number
+      })
+    ]);
+
+    // Extract unique commit authors (excluding bots)
+    const commitAuthors = extractCommitAuthors(prCommits);
+
+    // Calculate new assignees (authors not already assigned)
+    const existingAssignees = new Set(assignees.map(a => a.login));
+    const newAssignees = Array.from(commitAuthors).filter(
+      author => !existingAssignees.has(author)
+    );
+
+    // Add new assignees if any
+    if (newAssignees.length > 0) {
+      await addAssigneesToPR(github, context, newAssignees);
+    } else {
+      console.log('ℹ️ No new assignees to add');
+    }
+  } catch (error) {
+    console.error(`❌ Failed to process PR assignees: ${error.message}`);
+    throw error;
+  }
+};
+
+/**
+ * Extract GitHub usernames from commits, excluding bots
+ *
+ * @param {Array} commits - Array of commit objects from GitHub API
+ * @returns {Set<string>} Set of unique GitHub usernames
+ */
+function extractCommitAuthors(commits) {
+  const authors = new Set();
+
+  for (const commit of commits) {
+    if (commit.author?.login && commit.author.type !== 'Bot') {
+      authors.add(commit.author.login);
+    } else if (commit.author?.type === 'Bot') {
+      console.log(`⚠️ Skipping bot commit ${commit.sha.substring(0, 7)}`);
+    } else {
+      console.log(`⚠️ Skipping commit ${commit.sha.substring(0, 7)} (No linked GitHub user)`);
+    }
+  }
+
+  return authors;
+}
+
+/**
+ * Add assignees to a pull request
+ *
+ * @param {Object} github - GitHub API client
+ * @param {Object} context - Workflow context
+ * @param {Array<string>} assignees - Array of GitHub usernames to assign
+ */
+async function addAssigneesToPR(github, context, assignees) {
+  try {
+    console.log(`✅ Adding assignees: ${assignees.join(', ')}`);
+
+    await github.rest.issues.addAssignees({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      issue_number: context.issue.number,
+      assignees: assignees
+    });
+  } catch (error) {
+    console.error(`❌ Failed to add assignees: ${error.message}`);
+    throw error;
+  }
+}

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -12,56 +12,14 @@ jobs:
     runs-on: ubuntu-slim
     permissions:
       pull-requests: write
+      issues: write
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Assign PR to all commit authors
         uses: actions/github-script@v7
         with:
           script: |
-            try {
-              // Fetch all commits and current PR info in parallel
-              const [{ data: commits }, { data: currentPr }] = await Promise.all([
-                github.rest.pulls.listCommits({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  pull_number: context.issue.number
-                }),
-                github.rest.pulls.get({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  pull_number: context.issue.number
-                })
-              ]);
-
-              // Extract GitHub usernames from commits
-              const authors = new Set();  // Set automatically removes duplicates
-              for (const commit of commits) {
-                if (commit.author?.login && commit.author.type !== 'Bot') {
-                  authors.add(commit.author.login);
-                } else if (commit.author?.type === 'Bot') {
-                  console.log(`⚠️ Skipping commit ${commit.sha} (Bot commit)`);
-                } else {
-                  console.log(`⚠️ Skipping commit ${commit.sha} (No linked GitHub user)`);
-                }
-              }
-
-              const currentAssignees = new Set(currentPr.assignees.map(a => a.login));
-
-              // Filter out users who are already assigned
-              const newAssignees = Array.from(authors).filter(a => !currentAssignees.has(a));
-
-              // Add only new assignees to the PR
-              if (newAssignees.length > 0) {
-                console.log(`✅ Adding assignees: ${newAssignees.join(', ')}`);
-                await github.rest.issues.addAssignees({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: context.issue.number,
-                  assignees: newAssignees
-                });
-              } else {
-                console.log(`ℹ️ No new assignees to add`);
-              }
-            } catch (error) {
-              console.error(`❌ Error: ${error.message}`);
-              throw error;
-            }
+            const autoAssign = require('./.github/scripts/auto-assign.js');
+            await autoAssign({ github, context });


### PR DESCRIPTION
## WHY
手動で設定するのが面倒！！
Assigneesを追加する意味は、PR欄がおしゃんになるだけ

## WHAT
- 権限が `write` な理由は、PRを編集 (assign追加、ラベル追加などなど) をするワークフローのため
- bashではなく、JSで書いている理由をざっくりと
<img width="611" height="261" alt="image" src="https://github.com/user-attachments/assets/2f0813cf-190a-4b1b-8be5-79a291eef1e4" />