### PR TITLE
chore: GitHub ActionsのバージョンをSHA付きに固定

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -15,10 +15,10 @@ jobs:
       issues: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Assign PR to all commit authors
-        uses: actions/github-script@v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const autoAssign = require('./.github/scripts/auto-assign.js');

--- a/.github/workflows/minishell-test.yml
+++ b/.github/workflows/minishell-test.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/norminette.yml
+++ b/.github/workflows/norminette.yml
@@ -19,12 +19,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 


### PR DESCRIPTION
## 変更内容

GitHub Actionsで使用しているサードパーティアクションのバージョンを特定のSHAにピン留めしました。

## 理由

GitHubの公式ドキュメントで推奨されているセキュリティベストプラクティスに従い、予期しない変更や悪意のある変更から保護します。

参考: https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>