### PR TITLE
fix: _GNU_SOURCE の再定義警告を解消

### DIFF
--- a/includes/repl.h
+++ b/includes/repl.h
@@ -3,16 +3,19 @@
 /*                                                        :::      ::::::::   */
 /*   repl.h                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: tshimizu <tshimizu@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*   By: nkojima <nkojima@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/11/24 12:48:38 by tshimizu          #+#    #+#             */
-/*   Updated: 2025/12/06 16:43:08 by tshimizu         ###   ########.fr       */
+/*   Updated: 2025/12/14 17:37:10 by nkojima          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #ifndef REPL_H
 # define REPL_H
-# define _GNU_SOURCE
+
+# ifndef _GNU_SOURCE
+#  define _GNU_SOURCE
+# endif
 
 # include <signal.h>
 # include <stdbool.h>


### PR DESCRIPTION
## What
`repl.h` の `_GNU_SOURCE` 定義を条件付きガードで囲み、コンパイラ側で既に定義されている場合は再定義しないように変更。

## Why
CI の `make test` 実行時に `warning: "_GNU_SOURCE" redefined` が発生していた（issue #29）。
コンパイルフラグで既に定義されている場合に、ヘッダ側で無条件に定義していたため。

Closes #29