### PR TITLE
ci: PRタイトルのバリデーションワークフローを追加

### DIFF
--- a/.github/workflows/pull_request_title_lint.yml
+++ b/.github/workflows/pull_request_title_lint.yml
@@ -1,0 +1,50 @@
+name: "Lint Pull Request Titles"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-slim
+    steps:
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        id: lint_pr_title
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Configure which types are allowed (newline-delimited).
+          types: |
+            feat
+            fix
+            refactor
+            docs
+            chore
+            test
+          # Configure that a scope must always be provided.
+          requireScope: false
+          # Configure which scopes are disallowed in PR titles.
+          # These are regex patterns auto-wrapped in `^ $`.
+          #
+          # We disable the following scopes:
+          # - UPPERCASE titles because we promote the use of lowercase
+          disallowScopes: |
+            [A-Z_-]+
+          # Configure additional validation for the subject based on a regex.
+          # Ensures that the subject doesn't start with an uppercase character.
+          subjectPattern: ^[^A-Z].*$
+          # If `subjectPattern` is configured, you can use this property to override
+          # the default error message that is shown when the pattern doesn't match.
+          # The variables `subject` and `title` can be used within the message.
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}"
+            didn't match the configured pattern.
+            Please ensure that the subject doesn't start with an uppercase character.
+            The scope should not be in UPPERCASE.


### PR DESCRIPTION
## What
PRタイトルがConventional Commitsに準拠しているかを自動チェックするGitHub Actionsワークフローを追加。
`amannn/action-semantic-pull-request`を使用し、`feat/fix/refactor/docs/chore/test`のtypeと小文字始まりのタイトルを強制。

## Why
Squashマージ運用でPRタイトルが最終コミットメッセージになるため、早期に機械的にチェックすることで履歴の一貫性を保つ。
レビュー前にフォーマットエラーを検出できるため、手戻りが減る。

## Notes
- [biomeのワークフロー](https://github.com/biomejs/biome/blob/main/.github/workflows/pull_request_title_lint.yaml)を参考に実装
- `ubuntu-slim`を使用（他のワークフローと統一）
- スコープは任意（`requireScope: false`）
- `GITHUB_TOKEN`は自動提供されるため追加設定不要

Closes #31