### PR TITLE
fix(exec): パイプ右側が command not found のときシェルがブロックする不具合を修正

### DIFF
--- a/src/exec/execute_ast.c
+++ b/src/exec/execute_ast.c
@@ -6,7 +6,7 @@
 /*   By: nkojima <nkojima@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/01/25 22:42:34 by nkojima           #+#    #+#             */
-/*   Updated: 2026/01/25 23:35:12 by nkojima          ###   ########.fr       */
+/*   Updated: 2026/02/01 00:54:06 by nkojima          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -68,8 +68,10 @@ static int	execute_pipe_node(t_ast_node *node)
 		return (pipe_fork_fail(fd, left));
 	close(fd[0]);
 	close(fd[1]);
-	waitpid(left, NULL, 0);
 	waitpid(right, &status_right, 0);
+	if (left > 0)
+		kill(left, SIGTERM);
+	waitpid(left, NULL, 0);
 	if (WIFEXITED(status_right))
 		return (WEXITSTATUS(status_right));
 	return (EXIT_FAILURE);


### PR DESCRIPTION
closes #48

## 概要
`cat | nosuch` のようにパイプ右側が command not found のとき、シェルが入力待ちのまま戻ってこない不具合を修正しました。

## 原因
- 親プロセスが 左子を先に `waitpid(left)` で待っていた
- 右子（nosuch）は command not found で即終了し、パイプの読み端を閉じる
- 左子（cat）は 標準入力（端末）からの読み でブロックしたまま終了しない
- 親は waitpid(left) でブロックし続け、プロンプトに戻れない

## 対応内容
- 右を先に `waitpid(right)` する（右は既に終了しているので即返る）
- 続けて `left > 0` のとき `kill(left, SIGTERM)` で左子を終了させる
- その後 `waitpid(left)` で左子を回収する

SIGTERM について
SIGTERM（15）: プロセスに「終了してほしい」と伝えるシグナル。受け取った側でハンドラや後片付けをしてから終了できる。
SIGKILL（9）: 即強制終了。ハンドラで捕まえられず、後片付けもできない。
左子（例: cat）を止めるだけなら SIGTERM で十分で、SIGKILL で強制終了する必要はない。