### PR TITLE
ci: make 失敗時にマージできないビルドワークフローを追加

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,30 @@
+name: Build (make)
+
+run-name: "Build for PR: ${{ github.event.pull_request.title }}"
+
+on: [push, pull_request]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-slim
+    timeout-minutes: 10
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@main
+
+      - name: Install readline
+        run: brew install readline
+
+      - name: Build (make)
+        run: make


### PR DESCRIPTION
Build (make) ワークフローを追加。Branch protection で必須にすると make が失敗している間はマージ不可になる。

Made with [Cursor](https://cursor.com)