### PR TITLE
fix(signal): グローバル変数を受信シグナル番号保持に変更

### DIFF
--- a/includes/repl.h
+++ b/includes/repl.h
@@ -31,6 +31,8 @@ typedef enum e_prompt_status
 	PROMPT_EOF
 }	t_prompt_status;
 
+extern volatile sig_atomic_t	g_signal_status;
+
 bool	run_repl(t_env *env);
 void	sigint_handler(int signo);
 bool	assign_signal_handler(int signum, void (*handler)(int), int flags);

--- a/src/exec/exec_heredoc.c
+++ b/src/exec/exec_heredoc.c
@@ -15,8 +15,6 @@
 
 #define INTERRUPTED -2
 
-extern volatile sig_atomic_t	g_interrupt;
-
 static int	create_heredoc_fd(char *delimiter)
 {
 	int		fd[2];
@@ -26,9 +24,9 @@ static int	create_heredoc_fd(char *delimiter)
 		return (SYSCALL_ERROR);
 	while (true)
 	{
-		g_interrupt = 0;
+		g_signal_status = 0;
 		line = readline("> ");
-		if (g_interrupt)
+		if (g_signal_status == SIGINT)
 			return (free(line), close(fd[0]), close(fd[1]), INTERRUPTED);
 		if (!line || ft_strcmp(line, delimiter) == 0)
 			return (free(line), close(fd[1]), fd[0]);

--- a/src/input/repl.c
+++ b/src/input/repl.c
@@ -13,7 +13,7 @@
 #include "executor.h"
 #include "minishell.h"
 
-volatile sig_atomic_t	g_interrupt = 1;
+volatile sig_atomic_t	g_signal_status = 0;
 
 int	noop(void)
 {
@@ -43,9 +43,9 @@ char	*read_prompt(t_prompt_status *status)
 	char	*input;
 
 	*status = PROMPT_OK;
-	g_interrupt = 0;
+	g_signal_status = 0;
 	input = readline("minishell$ ");
-	if (g_interrupt)
+	if (g_signal_status == SIGINT)
 	{
 		*status = PROMPT_INTERRUPT;
 		free(input);
@@ -80,7 +80,6 @@ bool	run_repl(t_env *env)
 
 void	sigint_handler(int signo)
 {
-	(void)signo;
-	g_interrupt = 1;
+	g_signal_status = signo;
 	rl_done = 1;
 }

--- a/tests/input/Milestone2.cpp
+++ b/tests/input/Milestone2.cpp
@@ -11,10 +11,9 @@ extern "C"
 TEST(SignalTest, SigintHandlerTest)
 {
 	rl_done = 0;
-	extern volatile sig_atomic_t g_interrupt;
-	g_interrupt = 0;
+	g_signal_status = 0;
 	sigint_handler(SIGINT);
-	EXPECT_EQ(g_interrupt, 1);
+	EXPECT_EQ(g_signal_status, SIGINT);
 	EXPECT_EQ(rl_done, 1);
 }
 


### PR DESCRIPTION
## 概要
- g_interrupt フラグ運用を廃止し、g_signal_status に変更
- signal handler で受信シグナル番号を保持
- prompt/heredoc の割り込み判定を SIGINT 比較へ変更
- extern 宣言を repl.h に集約

この変更理由は、issueに書いてある
必要ないと思ったら、closeしてくれて構わない

Closes #70