### PR TITLE
refactor(libft): `ft_isspace` を libft に移す

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@
 #                                                         :::      ::::::::    #
 #    Makefile                                           :+:      :+:    :+:    #
 #                                                     +:+ +:+         +:+      #
-#    By: tshimizu <tshimizu@student.42tokyo.jp>     +#+  +:+       +#+         #
+#    By: nkojima <nkojima@student.42tokyo.jp>       +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2025/11/29 10:14:46 by tshimizu          #+#    #+#              #
-#    Updated: 2026/02/08 15:24:29 by tshimizu         ###   ########.fr        #
+#    Updated: 2026/02/10 17:40:45 by nkojima          ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -49,7 +49,6 @@ RMDIR       = rm -rf
 #               SRC
 # ===============================
 SRC_UTILS   = utils/free.c\
-			utils/utils.c\
 			utils/free_ast.c
 
 SRC_INPUT   = input/repl.c\

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -36,7 +36,6 @@ void			free_split(char **arr);
 void			free_env_list(t_env *env);
 void			free_string_array(char **arr);
 void			free_redirects(t_redirect *redir);
-int				ft_isspace(int c);
 void			free_ast(t_ast_node *node);
 t_ast_node		*list_to_ast(t_token_list *token_list);
 t_ast_node		*parse(char *input, t_env *env, int last_status);

--- a/libs/libft/Makefile
+++ b/libs/libft/Makefile
@@ -25,6 +25,7 @@ SRC_FILES = isalpha \
 			isalnum \
 			isascii \
 			isprint \
+			isspace \
 			strlen \
 			memset \
 			bzero \

--- a/libs/libft/ft_atoi.c
+++ b/libs/libft/ft_atoi.c
@@ -12,11 +12,6 @@
 
 #include "libft.h"
 
-static int	ft_isspace(int c)
-{
-	return (c == ' ' || (c >= '\t' && c <= '\r'));
-}
-
 static const char	*skip_whitespace_and_sign(const char *str, int *sign)
 {
 	*sign = 1;

--- a/libs/libft/ft_isspace.c
+++ b/libs/libft/ft_isspace.c
@@ -1,16 +1,16 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   utils.c                                            :+:      :+:    :+:   */
+/*   ft_isspace.c                                       :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: tshimizu <tshimizu@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*   By: nkojima <nkojima@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2025/12/21 12:38:48 by tshimizu          #+#    #+#             */
-/*   Updated: 2025/12/21 12:39:02 by tshimizu         ###   ########.fr       */
+/*   Created: 2026/02/10 17:41:42 by nkojima           #+#    #+#             */
+/*   Updated: 2026/02/10 17:41:44 by nkojima          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "minishell.h"
+#include "libft.h"
 
 int	ft_isspace(int c)
 {

--- a/libs/libft/libft.h
+++ b/libs/libft/libft.h
@@ -23,6 +23,7 @@ int			ft_isdigit(int c);
 int			ft_isalnum(int c);
 int			ft_isascii(int c);
 int			ft_isprint(int c);
+int			ft_isspace(int c);
 size_t		ft_strlen(const char *str);
 void		*ft_memset(void *buf, int ch, size_t n);
 void		ft_bzero(void *s, size_t n);


### PR DESCRIPTION
closes #80 

## Why
issueにも書いたけど、`isspace` 自体標準関数なため。