### PR TITLE
feat: readline に関するリークを許容する

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: nkojima <nkojima@student.42tokyo.jp>       +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2025/11/29 10:14:46 by tshimizu          #+#    #+#              #
-#    Updated: 2026/02/10 17:40:45 by nkojima          ###   ########.fr        #
+#    Updated: 2026/02/12 11:31:21 by nkojima          ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -144,7 +144,7 @@ debug: re
 	@echo "$(GREEN)🚀 Debug build ready$(RESET)"
 
 valgrind: re
-	valgrind --leak-check=full --show-leak-kinds=all --track-fds=yes ./$(NAME)
+	valgrind --leak-check=full --show-leak-kinds=all --track-fds=yes --suppressions=readline.supp ./$(NAME)
 
 # ===============================
 #          RUN / TEST

--- a/readline.supp
+++ b/readline.supp
@@ -1,0 +1,7 @@
+{
+   <Readline>
+   Memcheck:Leak
+   ...
+   obj:*libreadline*
+   ...
+}


### PR DESCRIPTION
close #0

## Summary

課題pdfに、以下の文章が書いてあって valgrind 時にそれを無視するようにファイルを追加した

> The readline() function may cause memory leaks, but you are not required to fix them.
However, this does not mean your own code, yes the code you wrote, can have
memory leaks.

## Changes

- readlineライブラリに関するリークを全て無視する

still reachable が0になっていることを確認した!!
<img width="573" height="202" alt="image" src="https://github.com/user-attachments/assets/25f40180-53af-4525-bc29-6c20dd5dea12" />


## Notes
