### PR TITLE
refactor: utilsの重複処理を削除

### DIFF
--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   minishell.h                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: tshimizu <tshimizu@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*   By: nkojima <nkojima@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/11/24 12:48:22 by tshimizu          #+#    #+#             */
-/*   Updated: 2026/02/15 13:19:37 by tshimizu         ###   ########.fr       */
+/*   Updated: 2026/02/20 15:42:28 by nkojima          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,7 +32,6 @@ typedef struct s_command
 bool			init_signal_handlers(void);
 
 void			free_token_list(t_token_list *list);
-void			free_split(char **arr);
 void			free_env_list(t_env *env);
 void			free_string_array(char **arr);
 void			free_redirects(t_redirect *redir);

--- a/src/exec/command.c
+++ b/src/exec/command.c
@@ -6,7 +6,7 @@
 /*   By: nkojima <nkojima@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/12/14 00:00:00 by nkojima           #+#    #+#             */
-/*   Updated: 2025/12/14 20:33:19 by nkojima          ###   ########.fr       */
+/*   Updated: 2026/02/20 15:43:13 by nkojima          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -93,6 +93,6 @@ char	*find_command(char *cmd, char **envp)
 	if (!paths)
 		return (NULL);
 	result = search_in_paths(paths, cmd);
-	free_split(paths);
+	free_string_array(paths);
 	return (result);
 }

--- a/src/utils/free.c
+++ b/src/utils/free.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   free.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: tshimizu <tshimizu@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*   By: nkojima <nkojima@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/12/06 11:21:28 by tshimizu          #+#    #+#             */
-/*   Updated: 2026/02/15 13:22:14 by tshimizu         ###   ########.fr       */
+/*   Updated: 2026/02/20 15:41:37 by nkojima          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,18 +26,6 @@ void	free_token_list(t_token_list *list)
 	}
 	free(list->tokens);
 	free(list);
-}
-
-void	free_split(char **arr)
-{
-	size_t	i;
-
-	i = 0;
-	if (!arr)
-		return ;
-	while (arr[i])
-		free(arr[i++]);
-	free(arr);
 }
 
 void	free_env_list(t_env *env)

--- a/src/utils/free_ast.c
+++ b/src/utils/free_ast.c
@@ -3,31 +3,16 @@
 /*                                                        :::      ::::::::   */
 /*   free_ast.c                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: tshimizu <tshimizu@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*   By: nkojima <nkojima@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/12/06 11:21:28 by tshimizu          #+#    #+#             */
-/*   Updated: 2026/01/11 23:05:13 by tshimizu         ###   ########.fr       */
+/*   Updated: 2026/02/20 16:04:19 by nkojima          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 #include "constants.h"
 #include <unistd.h>
-
-void	free_argv(char **argv)
-{
-	int	i;
-
-	if (!argv)
-		return ;
-	i = 0;
-	while (argv[i])
-	{
-		free(argv[i]);
-		i++;
-	}
-	free(argv);
-}
 
 void	free_redirects(t_redirect *redir)
 {
@@ -48,7 +33,7 @@ void	free_cmd_data(t_cmd_data *cmd)
 {
 	if (!cmd)
 		return ;
-	free_argv(cmd->argv);
+	free_string_array(cmd->argv);
 	free_redirects(cmd->redirects);
 	free(cmd);
 }


### PR DESCRIPTION
## コード重複の排除

### 同一機能の関数が3つ存在

以下の3関数は全て「NULL終端の `char**` を全要素 free して配列自体も free する」という同一処理:

- `free_split` ([src/utils/free.c](src/utils/free.c) L31)
- `free_string_array` ([src/utils/free.c](src/utils/free.c) L57)
- `free_argv` ([src/utils/free_ast.c](src/utils/free_ast.c) L17)