### PR TITLE
hotfix: exit時のリークを修正

### DIFF
--- a/includes/constants.h
+++ b/includes/constants.h
@@ -22,6 +22,8 @@ typedef enum e_exit_status
 	EXIT_SIGNAL_BASE = 128
 }	t_exit_status;
 
+# define EXIT_FLAG 256
+
 // ファイルディスクリプタ
 typedef enum e_fd
 {

--- a/src/builtin/exit.c
+++ b/src/builtin/exit.c
@@ -34,15 +34,15 @@ int	builtin_exit(char **argv)
 {
 	long long	code;
 
+	ft_putendl_fd("exit", FD_STDERR);
 	if (!argv[1])
-		exit(EXIT_SUCCESS);
+		return (EXIT_FLAG | EXIT_SUCCESS);
 	if (!validate_str_to_ll(argv[1], &code))
 	{
 		print_numeric_argument_error(argv[1]);
-		exit(EXIT_BUILTIN_MISUSE);
+		return (EXIT_FLAG | EXIT_BUILTIN_MISUSE);
 	}
 	if (has_too_many_args(argv))
 		return (print_too_many_arguments_error());
-	exit((unsigned char)code);
-	return (EXIT_SUCCESS);
+	return (EXIT_FLAG | (unsigned char)code);
 }

--- a/src/input/repl.c
+++ b/src/input/repl.c
@@ -78,6 +78,11 @@ int	run_repl(t_env *env)
 			break ;
 		process_input(input, &env, &last_status);
 		free(input);
+		if (last_status & EXIT_FLAG)
+		{
+			last_status = last_status & 0xFF;
+			break ;
+		}
 	}
 	return (last_status);
 }


### PR DESCRIPTION
close #107 

## Summary
タイトル通り

<img width="691" height="344" alt="image" src="https://github.com/user-attachments/assets/07cc4b56-fcf8-4e6e-90d4-57172951cfa0" />

## Changes
`last_status & EXIT_FLAG`
-> `256` のビットが立っているか確認
-> 立っていれば「exit された」と判断

FLAGを用いて、実際の終了コードを返すようにしてる
<img width="653" height="217" alt="image" src="https://github.com/user-attachments/assets/0c856665-5eb8-4a56-960d-fd07e65cab5a" />


### 終了ステータスの伝播方法に関して
1. `builtin_exit` がステータスを返す
2. `execute_command` -> `execute_cmd_node` -> `execute_ast` -> `process_input` と戻る
3. `run_repl` で `last_status & EXIT_FLAG` が検出され、ループを抜ける
4. `main` が `return (last_status)` する

`main` の `return` でプロセスは終了して、その戻り値がプロセスの exit status になる。

### なぜ `EXIT_FLAG` が必要か
`run_repl` では、次の2つを区別する必要がある
1. exit が実行された -> ループを抜けてシェルを終了
2. 通常のコマンドが 0 を返した -> ループを続ける

`return (EXIT_FLAG | 0)` のように返すことで、「exitが実行された + 終了コード0」という情報を一つのintで伝播してる